### PR TITLE
Replace qubell with tonomi

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Starter Kit provides the basic building blocks for deploying, updating and scaling Java-based applications on Qubell Platform using Docker, and can be used as a starting point for your own automation project.
 
-[![Install](https://raw.github.com/qubell-bazaar/component-skeleton/master/img/install.png)](https://express.qubell.com/applications/upload?metadataUrl=https://raw.github.com/qubell-bazaar/component-petclinic-docker/master/meta.yml)
+[![Install](https://raw.github.com/qubell-bazaar/component-skeleton/master/img/install.png)](https://express.tonomi.com/applications/upload?metadataUrl=https://raw.github.com/qubell-bazaar/component-petclinic-docker/master/meta.yml)
 
 Pre-requisites
 --------------


### PR DESCRIPTION
express.qubell.com -> express.tonomi.com

Risk: Low

Impact: Install link updated to point to correct server

Observable Effect: Install link should work properly
